### PR TITLE
Maya 2025 patches

### DIFF
--- a/scripts/weights_editor_tool/classes/command_edit_weights.py
+++ b/scripts/weights_editor_tool/classes/command_edit_weights.py
@@ -1,12 +1,12 @@
 import copy
 
 from maya import cmds
-from PySide2 import QtWidgets
 
 from weights_editor_tool.widgets import weights_table_view
+from weights_editor_tool.widgets.widgets_utils import *
 
 
-class CommandEditWeights(QtWidgets.QUndoCommand):
+class CommandEditWeights(QUndoCommand):
     """
     Command to edit skin weights.
 

--- a/scripts/weights_editor_tool/classes/command_lock_infs.py
+++ b/scripts/weights_editor_tool/classes/command_lock_infs.py
@@ -1,9 +1,9 @@
 from maya import cmds
 
-from PySide2 import QtWidgets
+from weights_editor_tool.widgets.widgets_utils import *
 
 
-class CommandLockInfs(QtWidgets.QUndoCommand):
+class CommandLockInfs(QUndoCommand):
     """
     Command to toggle influence locks.
 

--- a/scripts/weights_editor_tool/classes/hotkey.py
+++ b/scripts/weights_editor_tool/classes/hotkey.py
@@ -1,5 +1,4 @@
-from PySide2 import QtCore
-from PySide2 import QtGui
+from weights_editor_tool.widgets.widgets_utils import *
 
 from weights_editor_tool.enums import Hotkeys
 
@@ -7,28 +6,28 @@ from weights_editor_tool.enums import Hotkeys
 class Hotkey:
 
     Defaults = {
-        Hotkeys.ToggleTableListViews: {"key": QtCore.Qt.Key_QuoteLeft, "ctrl": True},
-        Hotkeys.ShowUtilities: {"key": QtCore.Qt.Key_1, "ctrl": True},
-        Hotkeys.ShowAddPresets: {"key": QtCore.Qt.Key_2, "ctrl": True},
-        Hotkeys.ShowScalePresets: {"key": QtCore.Qt.Key_3, "ctrl": True},
-        Hotkeys.ShowSetPresets: {"key": QtCore.Qt.Key_4, "ctrl": True},
-        Hotkeys.ShowInfList: {"key": QtCore.Qt.Key_5, "ctrl": True},
-        Hotkeys.ShowInfColors: {"key": QtCore.Qt.Key_6, "ctrl": True},
-        Hotkeys.MirrorAll: {"key": QtCore.Qt.Key_M, "ctrl": True},
-        Hotkeys.Prune: {"key": QtCore.Qt.Key_P, "ctrl": True},
-        Hotkeys.PruneMaxInfs: {"key": QtCore.Qt.Key_P, "ctrl": True, "shift": True},
-        Hotkeys.RunSmooth: {"key": QtCore.Qt.Key_S, "ctrl": True, "shift": True},
-        Hotkeys.RunSmoothAllInfs: {"key": QtCore.Qt.Key_D, "ctrl": True, "shift": True},
-        Hotkeys.Undo: {"key": QtCore.Qt.Key_Z, "ctrl": True, "shift": True},
-        Hotkeys.Redo: {"key": QtCore.Qt.Key_X, "ctrl": True, "shift": True},
-        Hotkeys.GrowSelection: {"key": QtCore.Qt.Key_Greater},
-        Hotkeys.ShrinkSelection: {"key": QtCore.Qt.Key_Less},
-        Hotkeys.SelectEdgeLoop: {"key": QtCore.Qt.Key_E, "ctrl": True},
-        Hotkeys.SelectRingLoop: {"key": QtCore.Qt.Key_R, "ctrl": True},
-        Hotkeys.SelectPerimeter: {"key": QtCore.Qt.Key_T, "ctrl": True},
-        Hotkeys.SelectShell: {"key": QtCore.Qt.Key_A, "ctrl": True, "shift": True},
-        Hotkeys.ToggleInfLock: {"key": QtCore.Qt.Key_Space},
-        Hotkeys.ToggleInfLock2: {"key": QtCore.Qt.Key_L}
+        Hotkeys.ToggleTableListViews: {"key": Qt.Key_QuoteLeft, "ctrl": True},
+        Hotkeys.ShowUtilities: {"key": Qt.Key_1, "ctrl": True},
+        Hotkeys.ShowAddPresets: {"key": Qt.Key_2, "ctrl": True},
+        Hotkeys.ShowScalePresets: {"key": Qt.Key_3, "ctrl": True},
+        Hotkeys.ShowSetPresets: {"key": Qt.Key_4, "ctrl": True},
+        Hotkeys.ShowInfList: {"key": Qt.Key_5, "ctrl": True},
+        Hotkeys.ShowInfColors: {"key": Qt.Key_6, "ctrl": True},
+        Hotkeys.MirrorAll: {"key": Qt.Key_M, "ctrl": True},
+        Hotkeys.Prune: {"key": Qt.Key_P, "ctrl": True},
+        Hotkeys.PruneMaxInfs: {"key": Qt.Key_P, "ctrl": True, "shift": True},
+        Hotkeys.RunSmooth: {"key": Qt.Key_S, "ctrl": True, "shift": True},
+        Hotkeys.RunSmoothAllInfs: {"key": Qt.Key_D, "ctrl": True, "shift": True},
+        Hotkeys.Undo: {"key": Qt.Key_Z, "ctrl": True, "shift": True},
+        Hotkeys.Redo: {"key": Qt.Key_X, "ctrl": True, "shift": True},
+        Hotkeys.GrowSelection: {"key": Qt.Key_Greater},
+        Hotkeys.ShrinkSelection: {"key": Qt.Key_Less},
+        Hotkeys.SelectEdgeLoop: {"key": Qt.Key_E, "ctrl": True},
+        Hotkeys.SelectRingLoop: {"key": Qt.Key_R, "ctrl": True},
+        Hotkeys.SelectPerimeter: {"key": Qt.Key_T, "ctrl": True},
+        Hotkeys.SelectShell: {"key": Qt.Key_A, "ctrl": True, "shift": True},
+        Hotkeys.ToggleInfLock: {"key": Qt.Key_Space},
+        Hotkeys.ToggleInfLock2: {"key": Qt.Key_L}
     }
 
     def __init__(self, caption, key, func, ctrl=False, shift=False, alt=False):
@@ -46,9 +45,9 @@ class Hotkey:
 
         # Only include shift for alphabetical characters or it won't work.
         return {
-            "shift": char.lower() != char and (QtCore.Qt.SHIFT & modifiers > 0),
-            "ctrl": QtCore.Qt.CTRL & modifiers > 0,
-            "alt": QtCore.Qt.ALT & modifiers > 0,
+            "shift": char.lower() != char and (Qt.SHIFT & modifiers > 0),
+            "ctrl": Qt.CTRL & modifiers > 0,
+            "alt": Qt.ALT & modifiers > 0,
             "key": key_event.key()
         }
 
@@ -67,16 +66,16 @@ class Hotkey:
         )
 
     def key_code(self):
-        ctrl = QtCore.Qt.CTRL if self.ctrl else 0
-        shift = QtCore.Qt.SHIFT if self.shift else 0
-        alt = QtCore.Qt.ALT if self.alt else 0
-        return self.key | ctrl | shift | alt
+        ctrl = int(self.ctrl)
+        shift = int(self.shift)
+        alt = int(self.alt)
+        return int(self.key) | ctrl | shift | alt
 
     def key_to_string(self):
         ctrl = "Ctrl" if self.ctrl else None
         shift = "Shift" if self.shift else None
         alt = "Alt" if self.alt else None
-        key = QtGui.QKeySequence(self.key).toString()
+        key = QKeySequence(self.key).toString()
         return " + ".join(filter(None, [ctrl, shift, alt, key]))
 
     def matches(self, other_hotkey):

--- a/scripts/weights_editor_tool/classes/skinned_obj.py
+++ b/scripts/weights_editor_tool/classes/skinned_obj.py
@@ -1,7 +1,7 @@
-import sys
+import glob
 import os
 import random
-import glob
+import sys
 
 if sys.version_info < (3, 0):
     import cPickle
@@ -12,8 +12,7 @@ from maya import cmds
 from maya import OpenMaya
 from maya.api import OpenMaya as om2
 
-from PySide2 import QtGui
-from PySide2 import QtWidgets
+from weights_editor_tool.widgets.widgets_utils import *
 
 from weights_editor_tool import constants
 from weights_editor_tool.enums import ColorTheme
@@ -579,7 +578,7 @@ class SkinnedObj:
         hue_step = 360.0 / (len(infs))
 
         for i, inf in enumerate(infs):
-            color = QtGui.QColor()
+            color = QColor()
             color.setHsv(hue_step * i, sat, brightness)
             color.toRgb()
 

--- a/scripts/weights_editor_tool/weights_editor_utils.py
+++ b/scripts/weights_editor_tool/weights_editor_utils.py
@@ -1,6 +1,5 @@
 import sys
 import os
-import shiboken2
 
 from maya import cmds
 from maya import mel
@@ -8,9 +7,7 @@ from maya import OpenMaya
 from maya import OpenMayaUI
 from maya import OpenMayaAnim
 
-from PySide2 import QtCore
-from PySide2 import QtGui
-from PySide2 import QtWidgets
+from weights_editor_tool.widgets.widgets_utils import *
 
 
 from weights_editor_tool import constants
@@ -22,24 +19,24 @@ if sys.version_info > (3, 0):
 
 
 def show_error_msg(title, msg, parent):
-    QtWidgets.QMessageBox.critical(parent, title, msg)
+    QMessageBox.critical(parent, title, msg)
 
 
 def get_maya_window():
     if not cmds.about(batch=True):
         ptr = OpenMayaUI.MQtUtil.mainWindow()
-        return shiboken2.wrapInstance(long(ptr), QtWidgets.QWidget)
+        return shiboken2.wrapInstance(long(ptr), QWidget)
 
 
 def load_pixmap(file_name, width=None, height=None):
     resources_dir = os.path.abspath(os.path.join(__file__, "..", "resources", "icons"))
-    pixmap = QtGui.QPixmap(os.path.join(resources_dir, file_name))
+    pixmap = QPixmap(os.path.join(resources_dir, file_name))
 
     if width is not None:
-        pixmap = pixmap.scaledToWidth(width, QtCore.Qt.SmoothTransformation)
+        pixmap = pixmap.scaledToWidth(width, Qt.SmoothTransformation)
 
     if height is not None:
-        pixmap = pixmap.scaledToHeight(height, QtCore.Qt.SmoothTransformation)
+        pixmap = pixmap.scaledToHeight(height, Qt.SmoothTransformation)
 
     return pixmap
 
@@ -56,26 +53,26 @@ def create_shortcut(key_sequence, callback):
     maya_window = get_maya_window()
 
     if maya_window:
-        shortcut = QtWidgets.QShortcut(key_sequence, maya_window)
-        shortcut.setContext(QtCore.Qt.ApplicationShortcut)
+        shortcut = QShortcut(key_sequence, maya_window)
+        shortcut.setContext(Qt.ApplicationShortcut)
         shortcut.activated.connect(callback)
         return shortcut
 
 
-def wrap_layout(widgets, orientation=QtCore.Qt.Vertical, spacing=None, margins=None, parent=None):
-    if orientation == QtCore.Qt.Horizontal:
-        new_layout = QtWidgets.QHBoxLayout()
+def wrap_layout(widgets, orientation=Qt.Vertical, spacing=None, margins=None, parent=None):
+    if orientation == Qt.Horizontal:
+        new_layout = QHBoxLayout()
     else:
-        new_layout = QtWidgets.QVBoxLayout()
+        new_layout = QVBoxLayout()
 
     for widget in widgets:
         if widget == "stretch":
             new_layout.addStretch()
         elif widget == "splitter":
-            frame = QtWidgets.QFrame(parent=parent)
+            frame = QFrame(parent=parent)
             frame.setStyleSheet("QFrame {background-color: rgb(50, 50, 50);}")
 
-            if orientation == QtCore.Qt.Vertical:
+            if orientation == Qt.Vertical:
                 frame.setFixedHeight(2)
             else:
                 frame.setFixedWidth(2)
@@ -84,7 +81,7 @@ def wrap_layout(widgets, orientation=QtCore.Qt.Vertical, spacing=None, margins=N
         elif type(widget) == int:
             new_layout.addSpacing(widget)
         else:
-            if QtCore.QObject.isWidgetType(widget):
+            if QObject.isWidgetType(widget):
                 new_layout.addWidget(widget)
             else:
                 new_layout.addLayout(widget)
@@ -211,7 +208,7 @@ def lerp_color(start_color, end_color, blend_value):
     r = start_color.red() + (end_color.red() - start_color.red()) * blend_value
     g = start_color.green() + (end_color.green() - start_color.green()) * blend_value
     b = start_color.blue() + (end_color.blue() - start_color.blue()) * blend_value
-    return QtGui.QColor(r, g, b)
+    return QColor(r, g, b)
 
 
 def extract_indexes(flatten_list):

--- a/scripts/weights_editor_tool/widgets/about_dialog.py
+++ b/scripts/weights_editor_tool/widgets/about_dialog.py
@@ -1,42 +1,38 @@
-from PySide2 import QtCore
-from PySide2 import QtGui
-from PySide2 import QtWidgets
-
-from weights_editor_tool import constants
-from weights_editor_tool import weights_editor_utils as utils
+from weights_editor_tool import constants, weights_editor_utils as utils
+from weights_editor_tool.widgets.widgets_utils import *
 
 
-class AboutDialog(QtWidgets.QDialog):
+class AboutDialog(QDialog):
 
     def __init__(self, version, parent=None):
-        QtWidgets.QDialog.__init__(self, parent=parent)
+        QDialog.__init__(self, parent=parent)
 
         self._version = version
 
         self._create_gui()
 
     def _wrap_groupbox(self, title, msg):
-        label = QtWidgets.QLabel(msg, parent=self)
+        label = QLabel(msg, parent=self)
         label.setWordWrap(True)
-        label.setTextInteractionFlags(QtCore.Qt.TextSelectableByMouse | QtCore.Qt.LinksAccessibleByMouse)
-        label.setCursor(QtGui.QCursor(QtCore.Qt.IBeamCursor))
+        label.setTextInteractionFlags(Qt.TextSelectableByMouse | Qt.LinksAccessibleByMouse)
+        label.setCursor(QCursor(Qt.IBeamCursor))
         label.setOpenExternalLinks(True)
 
-        layout = QtWidgets.QVBoxLayout()
+        layout = QVBoxLayout()
         layout.addWidget(label)
 
-        groupbox = QtWidgets.QGroupBox(title, parent=self)
+        groupbox = QGroupBox(title, parent=self)
         groupbox.setLayout(layout)
 
         return groupbox
 
     def _create_gui(self):
-        self._logo_img = QtWidgets.QLabel(parent=self)
-        self._logo_img.setAlignment(QtCore.Qt.AlignCenter)
+        self._logo_img = QLabel(parent=self)
+        self._logo_img.setAlignment(Qt.AlignCenter)
         self._logo_img.setPixmap(utils.load_pixmap("about/logo.png", width=125))
 
-        self._version_label = QtWidgets.QLabel("Version v{}".format(self._version), parent=self)
-        self._version_label.setAlignment(QtCore.Qt.AlignCenter)
+        self._version_label = QLabel("Version v{}".format(self._version), parent=self)
+        self._version_label.setAlignment(Qt.AlignCenter)
         self._version_label.setStyleSheet(
             "QLabel {font-weight: bold; color: white;}")
 
@@ -74,7 +70,7 @@ class AboutDialog(QtWidgets.QDialog):
             "Bugs and features",
             "Please report any bugs on its <b><a href='{url}'>GitHub issues page</a></b>".format(url=constants.GITHUB_ISSUES))
 
-        self._scroll_layout = QtWidgets.QVBoxLayout()
+        self._scroll_layout = QVBoxLayout()
         self._scroll_layout.addWidget(self._table_tips_groupbox)
         self._scroll_layout.addWidget(self._inf_list_tips_groupbox)
         self._scroll_layout.addWidget(self._limitations_groupbox)
@@ -83,24 +79,24 @@ class AboutDialog(QtWidgets.QDialog):
         self._scroll_layout.addWidget(self._bugs_groupbox)
         self._scroll_layout.addStretch()
 
-        self._scroll_frame = QtWidgets.QFrame(parent=self)
+        self._scroll_frame = QFrame(parent=self)
         self._scroll_frame.setLayout(self._scroll_layout)
 
-        self._scroll_area = QtWidgets.QScrollArea(parent=self)
-        self._scroll_area.setFocusPolicy(QtCore.Qt.NoFocus)
+        self._scroll_area = QScrollArea(parent=self)
+        self._scroll_area.setFocusPolicy(Qt.NoFocus)
         self._scroll_area.setStyleSheet("QScrollArea {border: none;}")
         self._scroll_area.setWidget(self._scroll_frame)
         self._scroll_area.setWidgetResizable(True)
 
-        self._ok_button = QtWidgets.QPushButton("OK", parent=self)
+        self._ok_button = QPushButton("OK", parent=self)
         self._ok_button.clicked.connect(self.close)
 
-        self._ok_layout = QtWidgets.QHBoxLayout()
+        self._ok_layout = QHBoxLayout()
         self._ok_layout.addStretch()
         self._ok_layout.addWidget(self._ok_button)
         self._ok_layout.addStretch()
 
-        self._main_layout = QtWidgets.QVBoxLayout()
+        self._main_layout = QVBoxLayout()
         self._main_layout.addWidget(self._logo_img)
         self._main_layout.addWidget(self._version_label)
         self._main_layout.addWidget(self._scroll_area)

--- a/scripts/weights_editor_tool/widgets/abstract_weights_view.py
+++ b/scripts/weights_editor_tool/widgets/abstract_weights_view.py
@@ -1,82 +1,79 @@
 from maya import cmds
 
-from PySide2 import QtGui
-from PySide2 import QtCore
-from PySide2 import QtWidgets
-
-from weights_editor_tool.enums import ColorTheme
 from weights_editor_tool import weights_editor_utils as utils
+from weights_editor_tool.enums import ColorTheme
 from weights_editor_tool.widgets import custom_header_view
+from weights_editor_tool.widgets.widgets_utils import *
 
 
-class AbstractWeightsView(QtWidgets.QTableView):
+class AbstractWeightsView(QTableView):
 
-    key_pressed = QtCore.Signal(QtGui.QKeyEvent)
-    header_middle_clicked = QtCore.Signal(str)
-    display_inf_triggered = QtCore.Signal(str)
-    select_inf_verts_triggered = QtCore.Signal(str)
+    key_pressed = Signal(QKeyEvent)
+    header_middle_clicked = Signal(str)
+    display_inf_triggered = Signal(str)
+    select_inf_verts_triggered = Signal(str)
 
     def __init__(self, header_orientation, editor_inst):
         super(AbstractWeightsView, self).__init__(editor_inst)
 
-        self.setEditTriggers(QtWidgets.QAbstractItemView.NoEditTriggers)
+        self.setEditTriggers(QAbstractItemView.NoEditTriggers)
         self.setAlternatingRowColors(True)
-        self.setGridStyle(QtCore.Qt.DashLine)
+        self.setGridStyle(Qt.DashLine)
 
-        system_font = QtWidgets.QApplication.font()
+        system_font = QApplication.font()
 
         self._orientation = header_orientation
-        self._font = QtGui.QFont(system_font.family(), system_font.pixelSize())
+        self._font = QFont(system_font.family(), system_font.pixelSize())
         self._editor_inst = editor_inst
         self._old_skin_data = None  # Need to store this to work with undo/redo.
         self.table_model = None
 
         self._header = None
 
-        if header_orientation == QtCore.Qt.Horizontal:
+        if header_orientation == Qt.Horizontal:
             self._header = custom_header_view.CustomHeaderView(header_orientation, parent=self)
         else:
             self._header = custom_header_view.VerticalHeaderView(header_orientation, parent=self)
 
-        self._header.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
+        self._header.setContextMenuPolicy(Qt.CustomContextMenu)
         self._header.customContextMenuRequested.connect(self._header_on_context_trigger)
         self._header.header_left_clicked.connect(self._header_on_left_clicked)
         self._header.header_middle_clicked.connect(self._header_on_middle_clicked)
 
-        if header_orientation == QtCore.Qt.Horizontal:
+        if header_orientation == Qt.Horizontal:
             self.setHorizontalHeader(self._header)
         else:
             self.setVerticalHeader(self._header)
 
-        self._lock_inf_action = QtWidgets.QAction(self)
+        self._lock_inf_action = QAction(self)
         self._lock_inf_action.setText("Lock influence")
         self._lock_inf_action.triggered.connect(self._lock_inf_on_triggered)
 
-        self._unlock_inf_action = QtWidgets.QAction(self)
+        self._unlock_inf_action = QAction(self)
         self._unlock_inf_action.setText("Unlock influence")
         self._unlock_inf_action.triggered.connect(self._unlock_inf_on_triggered)
 
-        self._display_inf_action = QtWidgets.QAction(self)
+        self._display_inf_action = QAction(self)
         self._display_inf_action.setText("Display influence (middle-click)")
         self._display_inf_action.triggered.connect(self._display_inf_on_triggered)
 
-        self._select_inf_verts_action = QtWidgets.QAction(self)
+        self._select_inf_verts_action = QAction(self)
         self._select_inf_verts_action.setText("Select vertexes effected by influence")
         self._select_inf_verts_action.triggered.connect(self._select_inf_verts_on_triggered)
 
-        self._select_inf_action = QtWidgets.QAction(self)
+        self._select_inf_action = QAction(self)
         self._select_inf_action.setText("Select influence")
         self._select_inf_action.triggered.connect(self._select_inf_on_triggered)
 
-        self._sort_weights_ascending_action = QtWidgets.QAction(self)
+        self._sort_weights_ascending_action = QAction(self)
         self._sort_weights_ascending_action.setText("Sort by weights (ascending)")
         self._sort_weights_ascending_action.triggered.connect(self._sort_ascending_on_triggered)
 
-        self._sort_weights_descending_action = QtWidgets.QAction(self)
+        self._sort_weights_descending_action = QAction(self)
         self._sort_weights_descending_action.setText("Sort by weights (descending)")
         self._sort_weights_descending_action.triggered.connect(self._sort_descending_on_triggered)
 
-        self._header_context_menu = QtWidgets.QMenu(parent=self)
+        self._header_context_menu = QMenu(parent=self)
         self._header_context_menu.addAction(self._display_inf_action)
         self._header_context_menu.addSeparator()
         self._header_context_menu.addAction(self._lock_inf_action)
@@ -125,7 +122,7 @@ class AbstractWeightsView(QtWidgets.QTableView):
                 msg = "Select the object's components to edit it."
                 img = utils.load_pixmap("table_view/select_points.png")
             
-            qp = QtGui.QPainter(self.viewport())
+            qp = QPainter(self.viewport())
             if not qp.isActive():
                 qp.begin(self)
 
@@ -138,21 +135,21 @@ class AbstractWeightsView(QtWidgets.QTableView):
             rect = paint_event.rect()
             rect.setTop(self.height() / 2)
 
-            qp.setPen(QtGui.QColor(255, 255, 255))
+            qp.setPen(QColor(255, 255, 255))
             qp.setFont(self._font)
-            qp.drawText(rect, QtCore.Qt.AlignHCenter | QtCore.Qt.AlignTop, msg)
+            qp.drawText(rect, Qt.AlignHCenter | Qt.AlignTop, msg)
             qp.end()
         
-        QtWidgets.QTableView.paintEvent(self, paint_event)
+        QTableView.paintEvent(self, paint_event)
 
     def keyPressEvent(self, event):
         self.key_pressed.emit(event)
     
     def mousePressEvent(self, event):
-        QtWidgets.QTableView.mousePressEvent(self, event)
+        QTableView.mousePressEvent(self, event)
 
         # Begins edit on current cell.
-        if event.button() == QtCore.Qt.MouseButton.RightButton:
+        if event.button() == Qt.MouseButton.RightButton:
             # Save this prior to any changes.
             self._old_skin_data = self._editor_inst.obj.skin_data.copy()
             self.edit(self.currentIndex())
@@ -216,10 +213,10 @@ class AbstractWeightsView(QtWidgets.QTableView):
     def emit_header_data_changed(self):
         inf_count = len(self.table_model.display_infs)
 
-        if self._orientation == QtCore.Qt.Horizontal:
-            self.table_model.headerDataChanged.emit(QtCore.Qt.Horizontal, 0, inf_count)
+        if self._orientation == Qt.Horizontal:
+            self.table_model.headerDataChanged.emit(Qt.Horizontal, 0, inf_count)
         else:
-            self.table_model.headerDataChanged.emit(QtCore.Qt.Vertical, 0, inf_count)
+            self.table_model.headerDataChanged.emit(Qt.Vertical, 0, inf_count)
 
     def color_headers(self, count):
         """
@@ -236,7 +233,7 @@ class AbstractWeightsView(QtWidgets.QTableView):
 
                 color = None
                 if rgb is not None:
-                    color = QtGui.QColor.fromRgbF(*rgb)
+                    color = QColor.fromRgbF(*rgb)
                 self.table_model.header_colors.append(color)
 
     def toggle_long_names(self, hidden):
@@ -248,18 +245,18 @@ class AbstractWeightsView(QtWidgets.QTableView):
             self.fit_headers_to_contents()
 
 
-class AbstractModel(QtCore.QAbstractTableModel):
+class AbstractModel(QAbstractTableModel):
     
     def __init__(self, editor_inst, parent=None):
         super(AbstractModel, self).__init__(parent)
         
         self._editor_inst = editor_inst
-        self._locked_text = QtGui.QColor(100, 100, 100)
-        self._full_weight_text = QtGui.QColor(QtCore.Qt.white)
-        self._low_weight_text = QtGui.QColor(QtCore.Qt.yellow)
-        self._zero_weight_text = QtGui.QColor(255, 50, 50)
-        self._header_locked_text = QtGui.QColor(QtCore.Qt.black)
-        self._header_active_inf_back_color = QtGui.QColor(0, 120, 180)
+        self._locked_text = QColor(100, 100, 100)
+        self._full_weight_text = QColor(Qt.white)
+        self._low_weight_text = QColor(Qt.yellow)
+        self._zero_weight_text = QColor(255, 50, 50)
+        self._header_locked_text = QColor(Qt.black)
+        self._header_active_inf_back_color = QColor(0, 120, 180)
 
         self.header_colors = []
         self.display_infs = []
@@ -282,7 +279,7 @@ class AbstractModel(QtCore.QAbstractTableModel):
         raise NotImplementedError
 
     def flags(self, index):
-        return QtCore.Qt.ItemIsEnabled | QtCore.Qt.ItemIsSelectable | QtCore.Qt.ItemIsEditable
+        return Qt.ItemIsEnabled | Qt.ItemIsSelectable | Qt.ItemIsEditable
 
     def get_inf(self, index):
         return self.display_infs[index]

--- a/scripts/weights_editor_tool/widgets/custom_double_spinbox.py
+++ b/scripts/weights_editor_tool/widgets/custom_double_spinbox.py
@@ -1,21 +1,20 @@
-from PySide2 import QtCore
-from PySide2 import QtWidgets
+from weights_editor_tool.widgets.widgets_utils import *
 
 
-class CustomDoubleSpinbox(QtWidgets.QDoubleSpinBox):
+class CustomDoubleSpinbox(QDoubleSpinBox):
     
     """
     Emits when enter is pressed.
     """
     
-    enter_pressed = QtCore.Signal(float)
+    enter_pressed = Signal(float)
     
     def __init__(self, parent=None):
         super(CustomDoubleSpinbox, self).__init__(parent)
     
     def keyPressEvent(self, event):
-        QtWidgets.QDoubleSpinBox.keyPressEvent(self, event)
+        QDoubleSpinBox.keyPressEvent(self, event)
         
         key_code = event.key()
-        if key_code == QtCore.Qt.Key_Enter or key_code == QtCore.Qt.Key_Return:
+        if key_code == Qt.Key_Enter or key_code == Qt.Key_Return:
             self.enter_pressed.emit(self.value())

--- a/scripts/weights_editor_tool/widgets/custom_header_view.py
+++ b/scripts/weights_editor_tool/widgets/custom_header_view.py
@@ -1,16 +1,15 @@
-from PySide2 import QtCore
-from PySide2 import QtWidgets
+from weights_editor_tool.widgets.widgets_utils import *
 
 
-class CustomHeaderView(QtWidgets.QHeaderView):
+class CustomHeaderView(QHeaderView):
     
     """
     Emits different mouse events.
     """
     
-    header_left_clicked = QtCore.Signal(int)
-    header_middle_clicked = QtCore.Signal(int)
-    header_right_clicked = QtCore.Signal(int)
+    header_left_clicked = Signal(int)
+    header_middle_clicked = Signal(int)
+    header_right_clicked = Signal(int)
     
     def __init__(self, orientation, parent=None):
         super(CustomHeaderView, self).__init__(orientation, parent)
@@ -20,14 +19,14 @@ class CustomHeaderView(QtWidgets.QHeaderView):
         index = self.logicalIndexAt(event.x(), event.y())
         self.last_index = index
         
-        if event.button() == QtCore.Qt.MouseButton.LeftButton:
+        if event.button() == Qt.MouseButton.LeftButton:
             self.header_left_clicked.emit(index)
-        elif event.button() == QtCore.Qt.MouseButton.MiddleButton:
+        elif event.button() == Qt.MouseButton.MiddleButton:
             self.header_middle_clicked.emit(index)
-        elif event.button() == QtCore.Qt.MouseButton.RightButton:
+        elif event.button() == Qt.MouseButton.RightButton:
             self.header_right_clicked.emit(index)
         
-        return QtWidgets.QHeaderView.mousePressEvent(self, event)
+        return QHeaderView.mousePressEvent(self, event)
 
 
 class VerticalHeaderView(CustomHeaderView):
@@ -39,7 +38,7 @@ class VerticalHeaderView(CustomHeaderView):
 
     def __init__(self, orientation, parent=None):
         super(VerticalHeaderView, self).__init__(orientation, parent)
-        self.size = QtCore.QSize(0, 0)
+        self.size = QSize(0, 0)
 
     def sizeHint(self):
         return self.size

--- a/scripts/weights_editor_tool/widgets/hotkeys_dialog.py
+++ b/scripts/weights_editor_tool/widgets/hotkeys_dialog.py
@@ -1,71 +1,68 @@
 from itertools import combinations
 
-from PySide2 import QtCore
-from PySide2 import QtGui
-from PySide2 import QtWidgets
-
 from weights_editor_tool import weights_editor_utils as utils
 from weights_editor_tool.classes.hotkey import Hotkey
+from weights_editor_tool.widgets.widgets_utils import *
 
 
-class HotkeysDialog(QtWidgets.QDialog):
+class HotkeysDialog(QDialog):
 
     def __init__(self, hotkeys, parent=None):
-        QtWidgets.QDialog.__init__(self, parent=parent)
+        QDialog.__init__(self, parent=parent)
 
         self._hotkey_edits = []
 
         self._create_gui(hotkeys)
 
     def _create_gui(self, hotkeys):
-        self._menu_bar = QtWidgets.QMenuBar(self)
-        self._menu_bar.setSizePolicy(QtWidgets.QSizePolicy.Preferred, QtWidgets.QSizePolicy.Fixed)
+        self._menu_bar = QMenuBar(self)
+        self._menu_bar.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Fixed)
 
-        self._settings_menu = QtWidgets.QMenu("&Tool settings", parent=self)
+        self._settings_menu = QMenu("&Tool settings", parent=self)
         self._menu_bar.addMenu(self._settings_menu)
 
-        self._reset_to_defaults_action = QtWidgets.QAction("Reset to defaults", self)
+        self._reset_to_defaults_action = QAction("Reset to defaults", self)
         self._reset_to_defaults_action.triggered.connect(self._reset_to_defaults_on_triggered)
         self._settings_menu.addAction(self._reset_to_defaults_action)
 
-        self._main_layout = QtWidgets.QVBoxLayout()
+        self._main_layout = QVBoxLayout()
         self._main_layout.addWidget(self._menu_bar)
 
         for hotkey in hotkeys:
-            label = QtWidgets.QLabel(hotkey.caption, parent=self)
+            label = QLabel(hotkey.caption, parent=self)
             label.setFixedWidth(150)
 
             key_edit = HotkeyEdit(hotkey.copy(), parent=self)
-            key_edit.setSizePolicy(QtWidgets.QSizePolicy.Preferred, QtWidgets.QSizePolicy.Preferred)
+            key_edit.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Preferred)
             self._hotkey_edits.append(key_edit)
 
-            hotkey_layout = QtWidgets.QHBoxLayout()
+            hotkey_layout = QHBoxLayout()
             hotkey_layout.addWidget(label)
             hotkey_layout.addWidget(key_edit)
             hotkey_layout.addStretch()
 
             self._main_layout.addLayout(hotkey_layout)
 
-        self._apply_button = QtWidgets.QPushButton("Apply changes", parent=self)
+        self._apply_button = QPushButton("Apply changes", parent=self)
         self._apply_button.clicked.connect(self._accept_on_clicked)
 
-        self._cancel_button = QtWidgets.QPushButton("Cancel", parent=self)
+        self._cancel_button = QPushButton("Cancel", parent=self)
         self._cancel_button.clicked.connect(self.reject)
 
-        self._buttons_layout = QtWidgets.QHBoxLayout()
+        self._buttons_layout = QHBoxLayout()
         self._buttons_layout.addWidget(self._apply_button)
         self._buttons_layout.addWidget(self._cancel_button)
 
-        self._main_frame = QtWidgets.QFrame(parent=self)
+        self._main_frame = QFrame(parent=self)
         self._main_frame.setLayout(self._main_layout)
 
-        self._scroll_area = QtWidgets.QScrollArea(parent=self)
-        self._scroll_area.setFocusPolicy(QtCore.Qt.NoFocus)
+        self._scroll_area = QScrollArea(parent=self)
+        self._scroll_area.setFocusPolicy(Qt.NoFocus)
         self._scroll_area.setStyleSheet("QScrollArea {border: none;}")
         self._scroll_area.setWidget(self._main_frame)
         self._scroll_area.setWidgetResizable(True)
 
-        self._tooltip_label = QtWidgets.QLabel(
+        self._tooltip_label = QLabel(
             "These hotkeys will temporarily override your native hotkeys until the tool is closed.",
             parent=self)
         self._tooltip_label.setWordWrap(True)
@@ -76,7 +73,7 @@ class HotkeysDialog(QtWidgets.QDialog):
             }
         """)
 
-        self._menu_layout = QtWidgets.QVBoxLayout()
+        self._menu_layout = QVBoxLayout()
         self._menu_layout.setContentsMargins(0, 0, 0, 0)
         self._menu_layout.addWidget(self._menu_bar)
         self._menu_layout.addWidget(self._tooltip_label)
@@ -117,14 +114,14 @@ class HotkeysDialog(QtWidgets.QDialog):
             utils.show_error_msg("Error!", str(err), self.parent())
 
 
-class HotkeyEdit(QtWidgets.QLineEdit):
+class HotkeyEdit(QLineEdit):
 
-    key_pressed = QtCore.Signal(QtWidgets.QLineEdit, QtGui.QKeyEvent)
+    key_pressed = Signal(QLineEdit, QKeyEvent)
 
     def __init__(self, hotkey, parent=None):
         self.hotkey = hotkey
 
-        QtWidgets.QLineEdit.__init__(self, self.hotkey.key_to_string(), parent=parent)
+        QLineEdit.__init__(self, self.hotkey.key_to_string(), parent=parent)
 
     def keyPressEvent(self, key_event):
         if not key_event.text():

--- a/scripts/weights_editor_tool/widgets/inf_list_view.py
+++ b/scripts/weights_editor_tool/widgets/inf_list_view.py
@@ -1,26 +1,22 @@
 import fnmatch
 from functools import partial
 
-from maya import cmds
-from maya import OpenMaya
-
-from PySide2 import QtGui
-from PySide2 import QtCore
-from PySide2 import QtWidgets
+from maya import cmds, OpenMaya
 
 from weights_editor_tool import weights_editor_utils as utils
+from weights_editor_tool.widgets.widgets_utils import *
 
 
-class InfListView(QtWidgets.QListView):
+class InfListView(QListView):
     
-    middle_clicked = QtCore.Signal(str)
-    toggle_locks_triggered = QtCore.Signal(list)
-    set_locks_triggered = QtCore.Signal(list, bool)
-    select_inf_verts_triggered = QtCore.Signal()
-    add_infs_to_verts_triggered = QtCore.Signal()
+    middle_clicked = Signal(str)
+    toggle_locks_triggered = Signal(list)
+    set_locks_triggered = Signal(list, bool)
+    select_inf_verts_triggered = Signal()
+    add_infs_to_verts_triggered = Signal()
     
     def __init__(self, editor_inst, parent=None):
-        QtWidgets.QListView.__init__(self, parent=parent)
+        QListView.__init__(self, parent=parent)
 
         self._last_filter = ""
 
@@ -28,36 +24,36 @@ class InfListView(QtWidgets.QListView):
         self.setModel(self.list_model)
 
         self.setAlternatingRowColors(True)
-        self.setSelectionMode(QtWidgets.QAbstractItemView.SelectionMode.ExtendedSelection)
-        self.setEditTriggers(QtWidgets.QAbstractItemView.NoEditTriggers)
+        self.setSelectionMode(QAbstractItemView.SelectionMode.ExtendedSelection)
+        self.setEditTriggers(QAbstractItemView.NoEditTriggers)
 
         self.doubleClicked.connect(self._on_double_clicked)
 
-        self._display_inf_action = QtWidgets.QAction(self)
+        self._display_inf_action = QAction(self)
         self._display_inf_action.setText("Display influence (middle-click)")
         self._display_inf_action.triggered.connect(self._display_current_inf)
 
-        self._select_infs_action = QtWidgets.QAction(self)
+        self._select_infs_action = QAction(self)
         self._select_infs_action.setText("Select influences (double-click)")
         self._select_infs_action.triggered.connect(self._select_current_infs)
 
-        self._select_inf_verts_action = QtWidgets.QAction(self)
+        self._select_inf_verts_action = QAction(self)
         self._select_inf_verts_action.setText("Select influence's vertexes")
         self._select_inf_verts_action.triggered.connect(self.select_inf_verts_triggered.emit)
 
-        self._lock_infs_action = QtWidgets.QAction(self)
+        self._lock_infs_action = QAction(self)
         self._lock_infs_action.setText("Lock influences (space)")
         self._lock_infs_action.triggered.connect(partial(self._set_inf_locks_on_triggered, True))
 
-        self._unlock_infs_action = QtWidgets.QAction(self)
+        self._unlock_infs_action = QAction(self)
         self._unlock_infs_action.setText("Unlock influences (space)")
         self._unlock_infs_action.triggered.connect(partial(self._set_inf_locks_on_triggered, False))
 
-        self._add_infs_to_verts_action = QtWidgets.QAction(self)
+        self._add_infs_to_verts_action = QAction(self)
         self._add_infs_to_verts_action.setText("Add influences to vertexes")
         self._add_infs_to_verts_action.triggered.connect(self.add_infs_to_verts_triggered.emit)
 
-        self._header_context_menu = QtWidgets.QMenu(parent=self)
+        self._header_context_menu = QMenu(parent=self)
         self._header_context_menu.addAction(self._display_inf_action)
         self._header_context_menu.addSeparator()
         self._header_context_menu.addAction(self._select_infs_action)
@@ -68,12 +64,12 @@ class InfListView(QtWidgets.QListView):
         self._header_context_menu.addSeparator()
         self._header_context_menu.addAction(self._add_infs_to_verts_action)
 
-        self.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
+        self.setContextMenuPolicy(Qt.CustomContextMenu)
         self.customContextMenuRequested.connect(self._on_context_requested)
 
     def mousePressEvent(self, event):
-        QtWidgets.QListView.mousePressEvent(self, event)
-        if event.button() == QtCore.Qt.MiddleButton:
+        QListView.mousePressEvent(self, event)
+        if event.button() == Qt.MiddleButton:
             self._display_current_inf()
     
     def keyPressEvent(self, event):
@@ -88,7 +84,7 @@ class InfListView(QtWidgets.QListView):
             if infs:
                 self.toggle_locks_triggered.emit(infs)
         else:
-            QtWidgets.QListView.keyPressEvent(self, event)
+            QListView.keyPressEvent(self, event)
 
     def _on_double_clicked(self, *args):
         self._select_current_infs()
@@ -182,10 +178,10 @@ class InfListView(QtWidgets.QListView):
             self.apply_filter(self._last_filter)
 
 
-class InfListModel(QtGui.QStandardItemModel):
+class InfListModel(QStandardItemModel):
     
     def __init__(self, editor_inst, parent=None):
-        QtGui.QStandardItemModel.__init__(self, parent=parent)
+        QStandardItemModel.__init__(self, parent=parent)
         
         self._editor_inst = editor_inst
         self.hide_long_names = True
@@ -193,15 +189,15 @@ class InfListModel(QtGui.QStandardItemModel):
         self._lock_icon = utils.load_pixmap("inf_view/lock.png", height=24)
         self._joint_icon = utils.load_pixmap("inf_view/joint.png", height=24)
 
-        self._size_hint = QtCore.QSize(1, 30)
+        self._size_hint = QSize(1, 30)
 
-        self._text_color = QtGui.QColor(QtCore.Qt.white)
-        self._locked_text_color = QtGui.QColor(130, 130, 130)
-        self._active_inf_back_color = QtGui.QColor(0, 120, 180)
-        self._active_inf_text_color = QtGui.QColor(QtCore.Qt.black)
+        self._text_color = QColor(Qt.white)
+        self._locked_text_color = QColor(130, 130, 130)
+        self._active_inf_back_color = QColor(0, 120, 180)
+        self._active_inf_text_color = QColor(Qt.black)
     
     def data(self, index, role):
-        QtGui.QStandardItemModel.data(self, index, role)
+        QStandardItemModel.data(self, index, role)
         
         if not index.isValid():
             return
@@ -209,16 +205,16 @@ class InfListModel(QtGui.QStandardItemModel):
         item = self.itemFromIndex(index)
         inf_name = item.text()
         
-        if role == QtCore.Qt.DisplayRole:
+        if role == Qt.DisplayRole:
             # Show influence's name.
             if self.hide_long_names:
                 return inf_name.split("|")[-1]
             return inf_name
-        elif role == QtCore.Qt.BackgroundColorRole:
+        elif role == Qt.BackgroundColorRole:
             # Show color influence.
             if inf_name == self._editor_inst.color_inf:
                 return self._active_inf_back_color
-        elif role == QtCore.Qt.ForegroundRole:
+        elif role == Qt.ForegroundRole:
             # Show locked influences.
             if inf_name in self._editor_inst.obj.infs:
                 inf_index = self._editor_inst.obj.infs.index(inf_name)
@@ -228,9 +224,9 @@ class InfListModel(QtGui.QStandardItemModel):
                     else:
                         return self._locked_text_color
             return self._text_color
-        elif role == QtCore.Qt.SizeHintRole:
+        elif role == Qt.SizeHintRole:
             return self._size_hint
-        elif role == QtCore.Qt.DecorationRole:
+        elif role == Qt.DecorationRole:
             icon = self._joint_icon
 
             if inf_name in self._editor_inst.obj.infs:
@@ -240,5 +236,5 @@ class InfListModel(QtGui.QStandardItemModel):
                     icon = self._lock_icon
 
             return icon
-        elif role == QtCore.Qt.ToolTipRole:
+        elif role == Qt.ToolTipRole:
             return inf_name

--- a/scripts/weights_editor_tool/widgets/presets_dialog.py
+++ b/scripts/weights_editor_tool/widgets/presets_dialog.py
@@ -1,13 +1,10 @@
 from maya import cmds
 
-from PySide2 import QtCore
-from PySide2 import QtGui
-from PySide2 import QtWidgets
-
 from weights_editor_tool import weights_editor_utils as utils
+from weights_editor_tool.widgets.widgets_utils import *
 
 
-class PresetsDialog(QtWidgets.QDialog):
+class PresetsDialog(QDialog):
 
     Defaults = {
         "add": [-0.2, -0.1, -0.05, -0.01, 0.01, 0.05, 0.1, 0.2],
@@ -16,7 +13,7 @@ class PresetsDialog(QtWidgets.QDialog):
     }
 
     def __init__(self, add_presets, scale_presets, set_presets, parent=None):
-        QtWidgets.QDialog.__init__(self, parent=parent)
+        QDialog.__init__(self, parent=parent)
 
         self._add_presets = add_presets
         self._scale_presets = scale_presets
@@ -25,17 +22,17 @@ class PresetsDialog(QtWidgets.QDialog):
         self._create_gui()
 
     def _create_gui(self):
-        self._menu_bar = QtWidgets.QMenuBar(self)
-        self._menu_bar.setSizePolicy(QtWidgets.QSizePolicy.Preferred, QtWidgets.QSizePolicy.Fixed)
+        self._menu_bar = QMenuBar(self)
+        self._menu_bar.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Fixed)
 
-        self._settings_menu = QtWidgets.QMenu("&Tool settings", parent=self)
+        self._settings_menu = QMenu("&Tool settings", parent=self)
         self._menu_bar.addMenu(self._settings_menu)
 
-        self._reset_to_defaults_action = QtWidgets.QAction("Reset to defaults", self)
+        self._reset_to_defaults_action = QAction("Reset to defaults", self)
         self._reset_to_defaults_action.triggered.connect(self._reset_to_defaults_on_triggered)
         self._settings_menu.addAction(self._reset_to_defaults_action)
 
-        self._tooltip_label = QtWidgets.QLabel(
+        self._tooltip_label = QLabel(
             "Enter numbers separated by commas to define which preset buttons to build",
             parent=self)
         self._tooltip_label.setWordWrap(True)
@@ -50,26 +47,26 @@ class PresetsDialog(QtWidgets.QDialog):
         self._scale_preset_widget = PresetWidget("Scale presets", (-100, 100), self._scale_presets, parent=self)
         self._set_preset_widget = PresetWidget("Set presets", (0, 1), self._set_presets, parent=self)
 
-        self._main_layout = QtWidgets.QVBoxLayout()
+        self._main_layout = QVBoxLayout()
         self._main_layout.addWidget(self._menu_bar)
         self._main_layout.addLayout(self._add_preset_widget.layout)
         self._main_layout.addLayout(self._scale_preset_widget.layout)
         self._main_layout.addLayout(self._set_preset_widget.layout)
 
-        self._apply_button = QtWidgets.QPushButton("Apply changes", parent=self)
+        self._apply_button = QPushButton("Apply changes", parent=self)
         self._apply_button.clicked.connect(self._accept_on_clicked)
 
-        self._cancel_button = QtWidgets.QPushButton("Cancel", parent=self)
+        self._cancel_button = QPushButton("Cancel", parent=self)
         self._cancel_button.clicked.connect(self.reject)
 
-        self._buttons_layout = QtWidgets.QHBoxLayout()
+        self._buttons_layout = QHBoxLayout()
         self._buttons_layout.addWidget(self._apply_button)
         self._buttons_layout.addWidget(self._cancel_button)
 
-        self._main_frame = QtWidgets.QFrame(parent=self)
+        self._main_frame = QFrame(parent=self)
         self._main_frame.setLayout(self._main_layout)
 
-        self._menu_layout = QtWidgets.QVBoxLayout()
+        self._menu_layout = QVBoxLayout()
         self._menu_layout.setContentsMargins(0, 0, 0, 0)
         self._menu_layout.addWidget(self._menu_bar)
         self._menu_layout.addWidget(self._tooltip_label)
@@ -109,7 +106,7 @@ class PresetWidget:
     def __init__(self, caption, min_max_range, values, parent=None):
         self.values = []
 
-        self._caption = QtWidgets.QLabel(caption, parent=parent)
+        self._caption = QLabel(caption, parent=parent)
         self._caption.setMinimumWidth(120)
         self._caption.setStyleSheet("""
             QLabel {
@@ -117,31 +114,31 @@ class PresetWidget:
             }
         """)
 
-        self._line_edit = QtWidgets.QLineEdit(parent=parent)
+        self._line_edit = QLineEdit(parent=parent)
         self._validator = CustomValidator(self._line_edit, min_max_range, parent=parent)
         self._validator.values_updated.connect(self._on_values_updated)
         self._line_edit.setText(self._validator.clean_up_items(values))
         self._line_edit.setPlaceholderText("No presets have been set")
         self._line_edit.setValidator(self._validator)
 
-        self._min_label = QtWidgets.QLabel("Min: {}".format(min_max_range[0]), parent=parent)
+        self._min_label = QLabel("Min: {}".format(min_max_range[0]), parent=parent)
         self._min_label.setMinimumWidth(50)
 
-        self._max_label = QtWidgets.QLabel("Max: {}".format(min_max_range[1]), parent=parent)
-        self._max_label.setAlignment(QtCore.Qt.AlignRight)
+        self._max_label = QLabel("Max: {}".format(min_max_range[1]), parent=parent)
+        self._max_label.setAlignment(Qt.AlignRight)
         self._max_label.setMinimumWidth(50)
 
         self._sub_layout = utils.wrap_layout(
             [self._min_label, self._line_edit, self._max_label],
-            QtCore.Qt.Horizontal,
+            Qt.Horizontal,
             margins=[20, 0, 20, 5])
 
-        self._sub_frame = QtWidgets.QWidget(parent=parent)
+        self._sub_frame = QWidget(parent=parent)
         self._sub_frame.setLayout(self._sub_layout)
 
         self.layout = utils.wrap_layout(
             [self._caption, self._sub_frame],
-            QtCore.Qt.Vertical)
+            Qt.Vertical)
 
         self.set_values(values)
 
@@ -153,12 +150,12 @@ class PresetWidget:
         self._line_edit.setText(self._validator.clean_up_items(values))
 
 
-class CustomValidator(QtGui.QValidator):
+class CustomValidator(QValidator):
 
-    values_updated = QtCore.Signal(list)
+    values_updated = Signal(list)
 
     def __init__(self, line_edit, min_max_range, parent=None):
-        QtGui.QValidator.__init__(self, parent)
+        QValidator.__init__(self, parent)
         self._line_edit = line_edit
         self._min_value = min_max_range[0]
         self._max_value = min_max_range[1]
@@ -176,14 +173,14 @@ class CustomValidator(QtGui.QValidator):
 
     def validate(self, txt, pos):
         if not txt:
-            return QtGui.QValidator.Acceptable, pos
+            return QValidator.Acceptable, pos
 
         valid_chars = ["-", ",", ".", " "]
         char = txt[pos - 1]
         if not char.isdigit() and char not in valid_chars:
-            return QtGui.QValidator.Invalid, pos
+            return QValidator.Invalid, pos
 
-        return QtGui.QValidator.Intermediate, pos
+        return QValidator.Intermediate, pos
 
     def fixup(self, txt):
         new_values = []

--- a/scripts/weights_editor_tool/widgets/weights_list_view.py
+++ b/scripts/weights_editor_tool/widgets/weights_list_view.py
@@ -1,15 +1,13 @@
-from PySide2 import QtCore
-from PySide2 import QtWidgets
-
 from weights_editor_tool.widgets import abstract_weights_view
+from weights_editor_tool.widgets.widgets_utils import *
 
 
 class ListView(abstract_weights_view.AbstractWeightsView):
 
     def __init__(self, editor_inst):
-        super(ListView, self).__init__(QtCore.Qt.Vertical, editor_inst)
+        super(ListView, self).__init__(Qt.Vertical, editor_inst)
 
-        self._sort_inf_name_action = QtWidgets.QAction(self)
+        self._sort_inf_name_action = QAction(self)
         self._sort_inf_name_action.setText("Sort by inf name")
         self._sort_inf_name_action.triggered.connect(self._sort_inf_name_on_triggered)
 
@@ -22,16 +20,16 @@ class ListView(abstract_weights_view.AbstractWeightsView):
         """
         Enables multiple cells to be set.
         """
-        is_cancelled = (hint == QtWidgets.QAbstractItemDelegate.RevertModelCache)
+        is_cancelled = (hint == QAbstractItemDelegate.RevertModelCache)
         
         if not is_cancelled:
             for index in self.selectedIndexes():
                 if index == self.currentIndex():
                     continue
                 
-                self.model().setData(index, None, QtCore.Qt.EditRole)
+                self.model().setData(index, None, Qt.EditRole)
         
-        QtWidgets.QTableView.closeEditor(self, editor, hint)
+        QTableView.closeEditor(self, editor, hint)
         
         if self.model().input_value is not None:
             self.model().input_value = None
@@ -47,15 +45,15 @@ class ListView(abstract_weights_view.AbstractWeightsView):
         self._old_skin_data = None
 
     def _sort_ascending_on_triggered(self):
-        self._reorder_by_values(QtCore.Qt.DescendingOrder)
+        self._reorder_by_values(Qt.DescendingOrder)
 
     def _sort_descending_on_triggered(self):
-        self._reorder_by_values(QtCore.Qt.AscendingOrder)
+        self._reorder_by_values(Qt.AscendingOrder)
 
     def _sort_inf_name_on_triggered(self):
         self._reorder_by_name()
 
-    def _reorder_by_name(self, order=QtCore.Qt.AscendingOrder):
+    def _reorder_by_name(self, order=Qt.AscendingOrder):
         self.begin_update()
         selection_data = self.save_table_selection()
 
@@ -89,7 +87,7 @@ class ListView(abstract_weights_view.AbstractWeightsView):
             row = self.table_model.display_infs.index(inf)
             selection_model = self.selectionModel()
             index = self.model().createIndex(row, 0)
-            flags = QtCore.QItemSelectionModel.ClearAndSelect | QtCore.QItemSelectionModel.Rows
+            flags = QItemSelectionModel.ClearAndSelect | QItemSelectionModel.Rows
             selection_model.select(index, flags)
         else:
             self.clearSelection()
@@ -142,7 +140,7 @@ class ListView(abstract_weights_view.AbstractWeightsView):
             return
 
         selection_model = self.selectionModel()
-        item_selection = QtCore.QItemSelection()
+        item_selection = QItemSelection()
 
         for inf, vert_indexes in selection_data.items():
             if inf not in self.table_model.display_infs:
@@ -150,9 +148,9 @@ class ListView(abstract_weights_view.AbstractWeightsView):
 
             row = self.table_model.display_infs.index(inf)
             index = self.model().index(row, 0)
-            item_selection.append(QtCore.QItemSelectionRange(index, index))
+            item_selection.append(QItemSelectionRange(index, index))
 
-        selection_model.select(item_selection, QtCore.QItemSelectionModel.Select)
+        selection_model.select(item_selection, QItemSelectionModel.Select)
 
     def fit_headers_to_contents(self):
         width = 0
@@ -169,7 +167,7 @@ class ListView(abstract_weights_view.AbstractWeightsView):
                 font_metrics.width(inf)
                 for inf in infs])[-1] + padding
 
-        self.verticalHeader().size = QtCore.QSize(width, 0)
+        self.verticalHeader().size = QSize(width, 0)
 
 
 class ListModel(abstract_weights_view.AbstractModel):
@@ -195,13 +193,13 @@ class ListModel(abstract_weights_view.AbstractModel):
         if not index.isValid():
             return
 
-        roles = [QtCore.Qt.ForegroundRole, QtCore.Qt.DisplayRole, QtCore.Qt.EditRole]
+        roles = [Qt.ForegroundRole, Qt.DisplayRole, Qt.EditRole]
 
         if role in roles:
             inf = self.get_inf(index.row())
             value = self.get_average_weight(inf)
             
-            if role == QtCore.Qt.ForegroundRole:
+            if role == Qt.ForegroundRole:
                 inf_index = self._editor_inst.obj.infs.index(inf)
                 is_locked = self._editor_inst.locks[inf_index]
                 if is_locked:
@@ -227,7 +225,7 @@ class ListModel(abstract_weights_view.AbstractModel):
         if not index.isValid():
             return False
         
-        if role != QtCore.Qt.EditRole:
+        if role != Qt.EditRole:
             return False
         
         # Triggers if first cell wasn't valid
@@ -259,9 +257,9 @@ class ListModel(abstract_weights_view.AbstractModel):
         """
         Deterimines the header's labels and style.
         """
-        if role == QtCore.Qt.ForegroundRole:
+        if role == Qt.ForegroundRole:
             # Color locks
-            if orientation == QtCore.Qt.Vertical:
+            if orientation == Qt.Vertical:
                 inf_name = self.display_infs[index]
                 
                 if inf_name in self._editor_inst.obj.infs:
@@ -270,9 +268,9 @@ class ListModel(abstract_weights_view.AbstractModel):
                     is_locked = self._editor_inst.locks[inf_index]
                     if is_locked:
                         return self._header_locked_text
-        elif role == QtCore.Qt.BackgroundColorRole:
+        elif role == Qt.BackgroundColorRole:
             # Color background
-            if orientation == QtCore.Qt.Vertical:
+            if orientation == Qt.Vertical:
                 # Use softimage colors
                 if self.header_colors:
                     color = self.header_colors[index]
@@ -283,8 +281,8 @@ class ListModel(abstract_weights_view.AbstractModel):
                     if self._editor_inst.color_inf is not None:
                         if self._editor_inst.color_inf == self.get_inf(index):
                             return self._header_active_inf_back_color
-        elif role == QtCore.Qt.DisplayRole:
-            if orientation == QtCore.Qt.Vertical:
+        elif role == Qt.DisplayRole:
+            if orientation == Qt.Vertical:
                 # Show top labels
                 if self.display_infs and index < len(self.display_infs):
                     inf = self.display_infs[index]
@@ -293,8 +291,8 @@ class ListModel(abstract_weights_view.AbstractModel):
                     return inf
             else:
                 return "Average values"
-        elif role == QtCore.Qt.ToolTipRole:
-            if orientation == QtCore.Qt.Vertical:
+        elif role == Qt.ToolTipRole:
+            if orientation == Qt.Vertical:
                 if self.display_infs and index < len(self.display_infs):
                     return self.display_infs[index]
 

--- a/scripts/weights_editor_tool/widgets/weights_table_view.py
+++ b/scripts/weights_editor_tool/widgets/weights_table_view.py
@@ -1,23 +1,21 @@
 from maya import cmds
 
-from PySide2 import QtCore
-from PySide2 import QtWidgets
-
 from weights_editor_tool import weights_editor_utils as utils
 from weights_editor_tool.widgets import abstract_weights_view
+from weights_editor_tool.widgets.widgets_utils import *
 
 
 class TableView(abstract_weights_view.AbstractWeightsView):
 
-    update_ended = QtCore.Signal(bool)
+    update_ended = Signal(bool)
 
     def __init__(self, editor_inst):
-        super(TableView, self).__init__(QtCore.Qt.Horizontal, editor_inst)
+        super(TableView, self).__init__(Qt.Horizontal, editor_inst)
 
         self._selected_rows = set()
-        self._header.setSectionResizeMode(QtWidgets.QHeaderView.ResizeToContents)
+        self._header.setSectionResizeMode(QHeaderView.ResizeToContents)
 
-        self._sort_weights_vert_order_action = QtWidgets.QAction(self)
+        self._sort_weights_vert_order_action = QAction(self)
         self._sort_weights_vert_order_action.setText("Sort by weights (vertex order)")
         self._sort_weights_vert_order_action.triggered.connect(self._sort_vert_order_on_triggered)
 
@@ -27,23 +25,23 @@ class TableView(abstract_weights_view.AbstractWeightsView):
         self._set_model(table_model)
 
     def selectionChanged(self, selected, deselected):
-        QtWidgets.QTableView.selectionChanged(self, selected, deselected)
+        QTableView.selectionChanged(self, selected, deselected)
         self._cell_selection_on_changed()
 
     def closeEditor(self, editor, hint):
         """
         Enables multiple cells to be set.
         """
-        is_cancelled = (hint == QtWidgets.QAbstractItemDelegate.RevertModelCache)
+        is_cancelled = (hint == QAbstractItemDelegate.RevertModelCache)
         
         if not is_cancelled:
             for index in self.selectedIndexes():
                 if index == self.currentIndex():
                     continue
                 
-                self.model().setData(index, None, QtCore.Qt.EditRole)
+                self.model().setData(index, None, Qt.EditRole)
         
-        QtWidgets.QTableView.closeEditor(self, editor, hint)
+        QTableView.closeEditor(self, editor, hint)
         
         if self.model().input_value is not None:
             self.model().input_value = None
@@ -63,10 +61,10 @@ class TableView(abstract_weights_view.AbstractWeightsView):
         self._old_skin_data = None
 
     def _sort_ascending_on_triggered(self):
-        self._reorder_rows(self._header.last_index, QtCore.Qt.DescendingOrder)
+        self._reorder_rows(self._header.last_index, Qt.DescendingOrder)
 
     def _sort_descending_on_triggered(self):
-        self._reorder_rows(self._header.last_index, QtCore.Qt.AscendingOrder)
+        self._reorder_rows(self._header.last_index, Qt.AscendingOrder)
 
     def _sort_vert_order_on_triggered(self):
         self._reorder_rows(self._header.last_index, None)
@@ -111,7 +109,7 @@ class TableView(abstract_weights_view.AbstractWeightsView):
 
         Args:
             column(int): The influence to compare weights with.
-            order(QtCore.Qt.SortOrder): The direction to sort the weights by.
+            order(Qt.SortOrder): The direction to sort the weights by.
                                         If None, re-orders based on vertex index.
         """
         self.begin_update()
@@ -139,7 +137,7 @@ class TableView(abstract_weights_view.AbstractWeightsView):
             column = self.table_model.display_infs.index(inf)
             selection_model = self.selectionModel()
             index = self.model().createIndex(0, column)
-            flags = QtCore.QItemSelectionModel.ClearAndSelect | QtCore.QItemSelectionModel.Columns
+            flags = QItemSelectionModel.ClearAndSelect | QItemSelectionModel.Columns
             selection_model.select(index, flags)
         else:
             self.clearSelection()
@@ -205,7 +203,7 @@ class TableView(abstract_weights_view.AbstractWeightsView):
             return
 
         selection_model = self.selectionModel()
-        item_selection = QtCore.QItemSelection()
+        item_selection = QItemSelection()
 
         for inf, vert_indexes in selection_data.items():
             if inf not in self.table_model.display_infs:
@@ -219,9 +217,9 @@ class TableView(abstract_weights_view.AbstractWeightsView):
 
                 row = self._editor_inst.vert_indexes.index(vert_index)
                 index = self.model().index(row, column)
-                item_selection.append(QtCore.QItemSelectionRange(index, index))
+                item_selection.append(QItemSelectionRange(index, index))
 
-        selection_model.select(item_selection, QtCore.QItemSelectionModel.Select)
+        selection_model.select(item_selection, QItemSelectionModel.Select)
 
     def fit_headers_to_contents(self):
         for i in range(self.horizontalHeader().count()):
@@ -252,13 +250,13 @@ class TableModel(abstract_weights_view.AbstractModel):
         if not index.isValid():
             return
 
-        roles = [QtCore.Qt.ForegroundRole, QtCore.Qt.DisplayRole, QtCore.Qt.EditRole]
+        roles = [Qt.ForegroundRole, Qt.DisplayRole, Qt.EditRole]
 
         if role in roles:
             inf = self.get_inf(index.column())
             value = self._get_value_by_index(index)
             
-            if role == QtCore.Qt.ForegroundRole:
+            if role == Qt.ForegroundRole:
                 inf_index = self._editor_inst.obj.infs.index(inf)
                 is_locked = self._editor_inst.locks[inf_index]
                 if is_locked:
@@ -284,7 +282,7 @@ class TableModel(abstract_weights_view.AbstractModel):
         if not index.isValid():
             return False
         
-        if role != QtCore.Qt.EditRole:
+        if role != Qt.EditRole:
             return False
         
         # Triggers if first cell wasn't valid
@@ -324,9 +322,9 @@ class TableModel(abstract_weights_view.AbstractModel):
         """
         Deterimines the header's labels and style.
         """
-        if role == QtCore.Qt.ForegroundRole:
+        if role == Qt.ForegroundRole:
             # Color locks
-            if orientation == QtCore.Qt.Horizontal:
+            if orientation == Qt.Horizontal:
                 inf_name = self.display_infs[column]
                 
                 if inf_name in self._editor_inst.obj.infs:
@@ -335,9 +333,9 @@ class TableModel(abstract_weights_view.AbstractModel):
                     is_locked = self._editor_inst.locks[inf_index]
                     if is_locked:
                         return self._header_locked_text
-        elif role == QtCore.Qt.BackgroundColorRole:
+        elif role == Qt.BackgroundColorRole:
             # Color background
-            if orientation == QtCore.Qt.Horizontal:
+            if orientation == Qt.Horizontal:
                 # Use softimage colors
                 if self.header_colors:
                     color = self.header_colors[column]
@@ -348,8 +346,8 @@ class TableModel(abstract_weights_view.AbstractModel):
                     if self._editor_inst.color_inf is not None:
                         if self._editor_inst.color_inf == self.get_inf(column):
                             return self._header_active_inf_back_color
-        elif role == QtCore.Qt.DisplayRole:
-            if orientation == QtCore.Qt.Horizontal:
+        elif role == Qt.DisplayRole:
+            if orientation == Qt.Horizontal:
                 # Show top labels
                 if self.display_infs and column < len(self.display_infs):
                     inf = self.display_infs[column]
@@ -360,8 +358,8 @@ class TableModel(abstract_weights_view.AbstractModel):
                 # Show side labels
                 if self._editor_inst.vert_indexes and column < len(self._editor_inst.vert_indexes):
                     return "vtx[{0}]".format(self._editor_inst.vert_indexes[column])
-        elif role == QtCore.Qt.ToolTipRole:
-            if orientation == QtCore.Qt.Horizontal:
+        elif role == Qt.ToolTipRole:
+            if orientation == Qt.Horizontal:
                 if self.display_infs and column < len(self.display_infs):
                     return self.display_infs[column]
 

--- a/scripts/weights_editor_tool/widgets/widgets_utils.py
+++ b/scripts/weights_editor_tool/widgets/widgets_utils.py
@@ -1,0 +1,12 @@
+try:
+    import shiboken2
+    from PySide2.QtCore import *
+    from PySide2.QtGui import *
+    from PySide2.QtWidgets import *
+    from PySide2.QtNetwork import *
+except ImportError:
+    import shiboken6 as shiboken2
+    from PySide6.QtCore import *
+    from PySide6.QtGui import *
+    from PySide6.QtWidgets import *
+    from PySide6.QtNetwork import *


### PR DESCRIPTION
Maya 2025 uses PySide6 and shiboken6, so I had to try/except the imports to make it work across Maya versions.

I moved all Qt imports into widgets/widgets_utils.py and then imported that instead so this workaround only needs to happen in 1 place.
Additionally, because PySide6 moved a lot of things around between namespaces (QUndoStack to QtGui instead of QtWidgets for example), I opted to remove the namespace prefix everywhere.

The alternative would have been to identify every moved class and (in widgets_utils) reassign them to their old namespace in the PySide6 branch: `QtWidgets.QUndoStack = QtGui.QUndoStack`
But that seemed like a never ending task, and since all of Qt's classes are prefixed with a capital Q I think it is guarded enough against naming conflicts.

Resolves https://github.com/theRussetPotato/weights_editor/issues/11